### PR TITLE
Update gradle wrapper validation to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v4
     - uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/emulator-test.yml
+++ b/.github/workflows/emulator-test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v4
     - name: Enable KVM group perms
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v4
     - uses: actions/cache@v3
       with:
         path: |


### PR DESCRIPTION
# What
Update gradle wrapper validation action from v1 to v4 in all workflow files

# Why
The gradle/wrapper-validation-action@v1 is deprecated. Need to use gradle/actions/wrapper-validation@v4 as the recommended replacement.