### PR TITLE
Fix CodeQL testClasses task dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,5 +13,5 @@ allprojects {
 
 // CodeQL task for root project
 project.tasks.create("testClasses") {
-    dependsOn("allTests")
+    dependsOn(":rin:allTests")
 }


### PR DESCRIPTION
# What
Fix testClasses task to properly depend on :rin:allTests

# Why
CodeQL task needs correct dependency path to run successfully